### PR TITLE
Fix Run And Debug To Run Commands With Arguments in XSOAR

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Change Log
 
 # Unreleased
+- Fixed an issue where the **Run And Debug** command failed to execute properly when running commands with arguments in XSOAR.
 
 # [0.7.4] (2024-11-26)
 

--- a/src/runAndDebug.ts
+++ b/src/runAndDebug.ts
@@ -89,14 +89,14 @@ function argumentSorted(_list: vscode.QuickPickItem[]): vscode.QuickPickItem[] {
 }
 
 function runCommand(query: Map<string, string>) {
-    let cmd = `"${query.get('cmd')}`
+    let cmd = `${query.get('cmd')}`
     if (typeof cmd === 'string') {
         query.delete('cmd')
         const queryTest = Array.from(query.entries())
         queryTest.map((arg: [string, string]) => {
             cmd += ` ${arg[0]}=${arg[1]}`
         })
-        const q: string[] = ['run', '-q', cmd + `"`]
+        const q: string[] = ['run', '-q', cmd]
         TerminalManager.sendDemistoSDKCommand(q);
     }
 }


### PR DESCRIPTION
## Related Issues

fixes: [link](https://jira-dc.paloaltonetworks.com/browse/XSUP-46603) to the issue

## Description


Fixed an issue where the **Run And Debug** command failed to execute properly when running commands with arguments in XSOAR.

## Screenshots
### Before the fix
#### without argument: 
![image](https://github.com/user-attachments/assets/ef4eddfb-1c9a-4230-ba34-671078265c58)

#### with argument:

![image](https://github.com/user-attachments/assets/9978ac01-71f3-4064-907c-14b7d16014c8)



### After the fix
#### without argument: 
![image](https://github.com/user-attachments/assets/5f57664f-bad8-4beb-8878-3dcf1fcb7572)
#### with argument:
![image](https://github.com/user-attachments/assets/9509cfce-3bad-4b25-b97b-f23df0c83239)
